### PR TITLE
window starts fixed to stay in view, but switches to absolute so you can...

### DIFF
--- a/jquery.leanModal.js
+++ b/jquery.leanModal.js
@@ -46,6 +46,12 @@
         		
         		});
 
+            var top_position = $(modal_id).offset().top + "px";
+            $(modal_id).css({
+              'position' : 'absolute',
+              'top': top_position
+            });
+
         		$(modal_id).fadeTo(200,1);
 
                 e.preventDefault();


### PR DESCRIPTION
... scroll

Hi Finely Sliced. I stuck in this quick fix for my own needs. I figure a lot of other people may want this. I use the fix position that is default so the window always shows up on the window. But then after it is placed, I get the absolute top position of the window, and switch the CSS to position: absolute so that you can scroll the page in the case where the window is longer than the viewport (as is in my case). I don't know if you want this to be default or not, since if you only have small boxes, having a fixed position is probably more desirable, but maybe you want to make this into an optional configuration ('scrollable' or something similar). Let me know what you think, but I'll be using it in my projects. Thanks for the best lightbox solution I've found on the internet!
