### PR TITLE
Add focus to forms in modal

### DIFF
--- a/jquery.leanModal.js
+++ b/jquery.leanModal.js
@@ -7,7 +7,8 @@
             var defaults = {
                 top: 100,
                 overlay: 0.5,
-                closeButton: null
+                closeButton: null,
+		focusId: null
             }
             
             var overlay = $("<div id='lean_overlay'></div>");
@@ -52,7 +53,7 @@
         		});
 
         		$(modal_id).fadeTo(200,1);
-
+			$(o.focusId).focus();
                 e.preventDefault();
                 		
               	});


### PR DESCRIPTION
Small (2 lines) but important improvement. If you have a form in your modal, you can set the id of the element that will gain focus when modal will open.
You set the selector of the element to gain focus with a new option focusId.
