### PR TITLE
Allow non-integer value for "top" option

### DIFF
--- a/jquery.leanModal.js
+++ b/jquery.leanModal.js
@@ -5,7 +5,7 @@
         leanModal: function(options) {
  
             var defaults = {
-                top: 100,
+                top: '100px',
                 overlay: 0.5,
                 closeButton: null
             }
@@ -47,7 +47,7 @@
         			'z-index': 11000,
         			'left' : 50 + '%',
         			'margin-left' : -(modal_width/2) + "px",
-        			'top' : o.top + "px"
+        			'top' : o.top
         		
         		});
 


### PR DESCRIPTION
Useful when setting top option to value other than pixel. ie. "100%", "1em"
