### PR TITLE
Corrupting the DOM with multiple #lean_overlay elements

### DIFF
--- a/jquery.leanModal.js
+++ b/jquery.leanModal.js
@@ -11,9 +11,11 @@
             }
             
             var overlay = $("<div id='lean_overlay'></div>");
-            
-            $("body").append(overlay);
-                 
+
+            if (!$("#lean_overlay").length) {
+                $("body").append(overlay);
+            }
+
             options =  $.extend(defaults, options);
  
             return this.each(function() {


### PR DESCRIPTION
Hi there, I've just added a conditional to prevent multiple #lean_overlay elements when leanModal is called more than once.

commit message:
Without this change, leanModal can only be called once. On subsequent calls additional, spurious #lean_overlay divs are added. Multiple copies of the same id should not be created.
