### PR TITLE
Fixes missing event bubbling protection on close buttons

### DIFF
--- a/jquery.leanModal.js
+++ b/jquery.leanModal.js
@@ -24,12 +24,16 @@
               
               	var modal_id = $(this).attr("href");
 
-				$("#lean_overlay").click(function() { 
-                     close_modal(modal_id);                    
+				$("#lean_overlay").click(function(e) {
+                     close_modal(modal_id);
+                     e.preventDefault();
+                     return false;
                 });
-                
-                $(o.closeButton).click(function() { 
-                     close_modal(modal_id);                    
+
+                $(o.closeButton).click(function(e) {
+                     close_modal(modal_id);
+                     e.preventDefault();
+                     return false;
                 });
                          	
               	var modal_height = $(modal_id).outerHeight();
@@ -54,7 +58,7 @@
         		$(modal_id).fadeTo(200,1);
 
                 e.preventDefault();
-                		
+                return false;
               	});
              
             });


### PR DESCRIPTION
If an event handler is set via delegation on a parent container, as the modal is technically still a child of that container, the close action can lead to an undesirable bubbling. This commit fixes that by adding preventDefault and return false protection to all click events.
